### PR TITLE
Strip and lower case emails

### DIFF
--- a/biomage/account/account.py
+++ b/biomage/account/account.py
@@ -222,6 +222,7 @@ def create_users_list(user_list, header, input_env, overwrite):
         df = pd.read_csv(user_list, header=header, quoting=csv.QUOTE_ALL)
         for _, full_name, email in df.itertuples():
 
+            email = email.strip().lower()
             error = _validate_input(email, full_name)
             if error:
                 print(error)
@@ -230,7 +231,6 @@ def create_users_list(user_list, header, input_env, overwrite):
             password = generate_password()
 
             full_name = full_name.title()
-            email = email.lower()
 
             error = _create_user(full_name, email, password, userpool, overwrite)
             if error and not ("UsernameExistsException" in str(error) and overwrite):


### PR DESCRIPTION
Some users have trailing spaces when registering for the workshop. This is causing the script to fail. This PR cleans the inputted email before validation so trailing spaces doesn't cause a failure.